### PR TITLE
Fix: Issue 93 - OrganizationResponse has list of IdentityProvidersResponse (plural).

### DIFF
--- a/admin.rest.swagger-v2.1.json
+++ b/admin.rest.swagger-v2.1.json
@@ -3710,7 +3710,7 @@
                 "identity_providers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/IdentityProvidersResponse"
+                        "$ref": "#/definitions/IdentityProviderResponse"
                     },
                     "description": "A list of identity providers for the organization."
                 },

--- a/admin.rest.swagger-v2.json
+++ b/admin.rest.swagger-v2.json
@@ -2738,7 +2738,7 @@
                 "identity_providers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/IdentityProvidersResponse"
+                        "$ref": "#/definitions/IdentityProviderResponse"
                     },
                     "description": "A list of identity providers for the organization."
                 },


### PR DESCRIPTION
Fixes issue https://github.com/docusign/docusign-admin-python-client/issues/13 and https://github.com/docusign/OpenAPI-Specifications/issues/93